### PR TITLE
Foi adicionado testes unitários para MensalidadesController, HomeController e CepController

### DIFF
--- a/Codigo/Condosmart/CondosmartWeb.Test/Controllers/CepControllerTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Controllers/CepControllerTests.cs
@@ -1,0 +1,87 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CondosmartWeb.Controllers;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+using Moq.Protected;
+using System.Net;
+using System.Net.Http;
+
+namespace CondosmartWeb.Controllers.Tests
+{
+    [TestClass]
+    public class CepControllerTests
+    {
+        private CepController controller = null!;
+        private Mock<IHttpClientFactory> mockHttpClientFactory = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            mockHttpClientFactory = new Mock<IHttpClientFactory>();
+            controller = new CepController(mockHttpClientFactory.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            controller.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+        }
+
+        [TestMethod]
+        public async Task GetEndereco_CepVazio_RetornaBadRequest()
+        {
+            // Act
+            var result = await controller.GetEndereco("");
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+        }
+
+        [TestMethod]
+        public async Task GetEndereco_CepInvalido_RetornaBadRequest()
+        {
+            // Act
+            var result = await controller.GetEndereco("123");
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(BadRequestObjectResult));
+        }
+
+        [TestMethod]
+        public async Task GetEndereco_CepValido_RetornaJson()
+        {
+            // Arrange
+            var json = "{\"logradouro\":\"Praca da Se\",\"complemento\":\"\",\"bairro\":\"Se\",\"localidade\":\"Sao Paulo\",\"uf\":\"SP\"}";
+            var handler = new MockHttpMessageHandler(json, HttpStatusCode.OK);
+            var client = new HttpClient(handler);
+            mockHttpClientFactory.Setup(f => f.CreateClient(It.IsAny<string>())).Returns(client);
+
+            // Act
+            var result = await controller.GetEndereco("01001000") as JsonResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+    }
+
+    internal class MockHttpMessageHandler : HttpMessageHandler
+    {
+        private readonly string _response;
+        private readonly HttpStatusCode _statusCode;
+
+        public MockHttpMessageHandler(string response, HttpStatusCode statusCode)
+        {
+            _response = response;
+            _statusCode = statusCode;
+        }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            return Task.FromResult(new HttpResponseMessage
+            {
+                StatusCode = _statusCode,
+                Content = new StringContent(_response)
+            });
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/Controllers/HomeControllerTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Controllers/HomeControllerTests.cs
@@ -1,0 +1,72 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Condosmart.Controllers;
+using CondosmartWeb.Models;
+using CondosmartWeb.Services;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Condosmart.Models;
+using Microsoft.Extensions.Logging;
+using Moq;
+
+namespace CondosmartWeb.Controllers.Tests
+{
+    [TestClass]
+    public class HomeControllerTests
+    {
+        private HomeController controller = null!;
+        private Mock<ILogger<HomeController>> mockLogger = null!;
+        private Mock<IAdminDashboardService> mockDashboardService = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            mockLogger = new Mock<ILogger<HomeController>>();
+            mockDashboardService = new Mock<IAdminDashboardService>();
+
+            controller = new HomeController(mockLogger.Object, mockDashboardService.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            controller.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+        }
+
+        [TestMethod]
+        public void Index_RetornaViewComDashboard()
+        {
+            // Arrange
+            var dashboard = new DashboardViewModel { TotalUnidades = 10 };
+            mockDashboardService.Setup(s => s.Build()).Returns(dashboard);
+
+            // Act
+            var result = controller.Index() as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(dashboard, result.Model);
+        }
+
+        [TestMethod]
+        public void Privacy_RetornaView()
+        {
+            // Act
+            var result = controller.Privacy() as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+        }
+
+        [TestMethod]
+        public void Error_RetornaViewComRequestId()
+        {
+            // Act
+            var result = controller.Error() as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            var model = result.Model as ErrorViewModel;
+            Assert.IsNotNull(model);
+            Assert.IsFalse(string.IsNullOrEmpty(model.RequestId));
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/Controllers/MensalidadesControllerTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Controllers/MensalidadesControllerTests.cs
@@ -1,0 +1,92 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using CondosmartWeb.Controllers;
+using CondosmartWeb.Models;
+using CondosmartWeb.Services;
+using Core.Models;
+using Core.Service;
+using AutoMapper;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ViewFeatures;
+using Moq;
+
+namespace CondosmartWeb.Controllers.Tests
+{
+    [TestClass]
+    public class MensalidadesControllerTests
+    {
+        private MensalidadesController controller = null!;
+        private Mock<IMensalidadeService> mockMensalidadeService = null!;
+        private Mock<ICondominioService> mockCondominioService = null!;
+        private Mock<IUnidadesResidenciaisService> mockUnidadesService = null!;
+        private Mock<ICondominioContextService> mockCondominioContextService = null!;
+        private Mock<INotificacaoService> mockNotificacaoService = null!;
+        private Mock<IMapper> mockMapper = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            mockMensalidadeService = new Mock<IMensalidadeService>();
+            mockCondominioService = new Mock<ICondominioService>();
+            mockUnidadesService = new Mock<IUnidadesResidenciaisService>();
+            mockCondominioContextService = new Mock<ICondominioContextService>();
+            mockNotificacaoService = new Mock<INotificacaoService>();
+            mockMapper = new Mock<IMapper>();
+
+            controller = new MensalidadesController(
+                mockMensalidadeService.Object,
+                mockCondominioService.Object,
+                mockUnidadesService.Object,
+                mockCondominioContextService.Object,
+                mockNotificacaoService.Object,
+                mockMapper.Object);
+
+            var httpContext = new DefaultHttpContext();
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            controller.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+            controller.Url = new Mock<IUrlHelper>().Object;
+        }
+
+        [TestMethod]
+        public void Details_IdExistente_RetornaView()
+        {
+            // Arrange
+            var mensalidade = new Mensalidade { Id = 1 };
+            var viewModel = new MensalidadeViewModel { Id = 1 };
+            mockMensalidadeService.Setup(s => s.GetById(1)).Returns(mensalidade);
+            mockMapper.Setup(m => m.Map<MensalidadeViewModel>(mensalidade)).Returns(viewModel);
+
+            // Act
+            var result = controller.Details(1) as ViewResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual(viewModel, result.Model);
+        }
+
+        [TestMethod]
+        public void Details_IdInexistente_RetornaNotFound()
+        {
+            // Arrange
+            mockMensalidadeService.Setup(s => s.GetById(99)).Returns((Mensalidade?)null);
+
+            // Act
+            var result = controller.Details(99);
+
+            // Assert
+            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public void Comprovante_RedirecionaParaDetails()
+        {
+            // Act
+            var result = controller.Comprovante(5) as RedirectToActionResult;
+
+            // Assert
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Details", result.ActionName);
+            Assert.AreEqual("Comprovante indisponivel enquanto o fluxo de pagamento nao for implementado.", controller.TempData["Erro"]);
+        }
+    }
+}


### PR DESCRIPTION
Adicionados 3 novos arquivos de testes unitários para Controllers utilizando MSTest e Moq:

  - MensalidadesControllerTests – testa Details (id existente e inexistente) e Comprovante
  - HomeControllerTests – testa Index, Privacy e Error
  - CepControllerTests – testa GetEndereco com CEP vazio, inválido e válido
  
  Resolved #231 