### PR TITLE
Foi adicionado os testes de integração para VisitanteService, ChamadoService e AtaService

### DIFF
--- a/Codigo/Condosmart/CondosmartWeb.Test/Service/AtaServiceTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Service/AtaServiceTests.cs
@@ -1,0 +1,60 @@
+using Core.Data;
+using Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Service;
+
+namespace CondosmartWeb.Tests.Service
+{
+    [TestClass]
+    public class AtaServiceTests
+    {
+        private CondosmartContext context = null!;
+        private AtaService service = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<CondosmartContext>()
+                .UseInMemoryDatabase(databaseName: $"TestDb_{Guid.NewGuid()}")
+                .Options;
+
+            context = new CondosmartContext(options);
+            service = new AtaService(context);
+
+            context.Condominios.Add(new Condominio { Id = 1, Nome = "Condominio Teste", Cnpj = "12345678000195" });
+            context.Atas.Add(new Ata { Id = 1, Titulo = "Ata Teste", DataReuniao = new DateOnly(2026, 1, 15), CondominioId = 1 });
+            context.SaveChanges();
+        }
+
+        [TestCleanup]
+        public void Cleanup() => context?.Dispose();
+
+        [TestMethod]
+        public void CreateTest_ComDadosValidos_CriaAta()
+        {
+            var ata = new Ata { Titulo = "Nova Ata", DataReuniao = new DateOnly(2026, 5, 10), CondominioId = 1 };
+
+            int id = service.Create(ata);
+
+            Assert.IsTrue(id > 0);
+            Assert.AreEqual("Nova Ata", service.GetById(id)!.Titulo);
+        }
+
+        [TestMethod]
+        public void GetByIdTest_ComIdExistente_RetornaAta()
+        {
+            var result = service.GetById(1);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Ata Teste", result.Titulo);
+        }
+
+        [TestMethod]
+        public void DeleteTest_ComIdValido_RemoveAta()
+        {
+            service.Delete(1);
+
+            Assert.IsNull(service.GetById(1));
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/Service/ChamadoServiceTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Service/ChamadoServiceTests.cs
@@ -1,0 +1,60 @@
+using Core.Data;
+using Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Service;
+
+namespace CondosmartWeb.Tests.Service
+{
+    [TestClass]
+    public class ChamadoServiceTests
+    {
+        private CondosmartContext context = null!;
+        private ChamadoService service = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<CondosmartContext>()
+                .UseInMemoryDatabase(databaseName: $"TestDb_{Guid.NewGuid()}")
+                .Options;
+
+            context = new CondosmartContext(options);
+            service = new ChamadoService(context);
+
+            context.Condominios.Add(new Condominio { Id = 1, Nome = "Condominio Teste", Cnpj = "12345678000195" });
+            context.Chamados.Add(new Chamado { Id = 1, Descricao = "Chamado Teste", Status = "aberto", CondominioId = 1 });
+            context.SaveChanges();
+        }
+
+        [TestCleanup]
+        public void Cleanup() => context?.Dispose();
+
+        [TestMethod]
+        public void CreateTest_ComDadosValidos_CriaChamado()
+        {
+            var chamado = new Chamado { Descricao = "Novo Chamado", Status = "aberto", CondominioId = 1 };
+
+            int id = service.Create(chamado);
+
+            Assert.IsTrue(id > 0);
+            Assert.AreEqual("Novo Chamado", service.GetById(id)!.Descricao);
+        }
+
+        [TestMethod]
+        public void GetAllTest_RetornaTodosOsChamados()
+        {
+            var result = service.GetAll();
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual(1, result.Count);
+        }
+
+        [TestMethod]
+        public void DeleteTest_ComIdValido_RemoveChamado()
+        {
+            service.Delete(1);
+
+            Assert.IsNull(service.GetById(1));
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/Service/VisitanteServiceTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Service/VisitanteServiceTests.cs
@@ -1,0 +1,60 @@
+using Core.Data;
+using Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Service;
+
+namespace CondosmartWeb.Tests.Service
+{
+    [TestClass]
+    public class VisitanteServiceTests
+    {
+        private CondosmartContext context = null!;
+        private VisitanteService service = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<CondosmartContext>()
+                .UseInMemoryDatabase(databaseName: $"TestDb_{Guid.NewGuid()}")
+                .Options;
+
+            context = new CondosmartContext(options);
+            service = new VisitanteService(context);
+
+            context.Moradores.Add(new Morador { Id = 1, Nome = "Morador Teste", Cpf = "11111111111", Email = "m@t.com" });
+            context.Visitantes.Add(new Visitantes { Id = 1, Nome = "Visitante 1", Telefone = "11999999999", MoradorId = 1 });
+            context.SaveChanges();
+        }
+
+        [TestCleanup]
+        public void Cleanup() => context?.Dispose();
+
+        [TestMethod]
+        public void CreateTest_ComDadosValidos_CriaVisitante()
+        {
+            var visitante = new Visitantes { Nome = "Novo Visitante", Telefone = "11888888888", MoradorId = 1 };
+
+            int id = service.Create(visitante);
+
+            Assert.IsTrue(id > 0);
+            Assert.AreEqual("Novo Visitante", service.GetById(id)!.Nome);
+        }
+
+        [TestMethod]
+        public void GetByIdTest_ComIdExistente_RetornaVisitante()
+        {
+            var result = service.GetById(1);
+
+            Assert.IsNotNull(result);
+            Assert.AreEqual("Visitante 1", result.Nome);
+        }
+
+        [TestMethod]
+        public void DeleteTest_ComIdValido_RemoveVisitante()
+        {
+            service.Delete(1);
+
+            Assert.IsNull(service.GetById(1));
+        }
+    }
+}

--- a/Codigo/Condosmart/Core/Data/CondosmartContext.cs
+++ b/Codigo/Condosmart/Core/Data/CondosmartContext.cs
@@ -42,7 +42,10 @@ public partial class CondosmartContext : DbContext
     public virtual DbSet<Mensalidade> Mensalidades { get; set; }
 
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
-        => optionsBuilder.UseMySql("server=localhost;port=3306;user=root;password=123456;database=condosmart", Microsoft.EntityFrameworkCore.ServerVersion.Parse("8.0.44-mysql"));
+    {
+        if (!optionsBuilder.IsConfigured)
+            optionsBuilder.UseMySql("server=localhost;port=3306;user=root;password=123456;database=condosmart", Microsoft.EntityFrameworkCore.ServerVersion.Parse("8.0.44-mysql"));
+    }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {


### PR DESCRIPTION
Adicionados 3 novos arquivos de testes de integração para classes Service utilizando MSTest com InMemoryDatabase:

  - VisitanteServiceTests – testa Create, GetById e Delete
  - ChamadoServiceTests – testa Create, GetAll e Delete
  - AtaServiceTests – testa Create, GetById e Delete

  Correção necessária

  Adicionada guarda if (!optionsBuilder.IsConfigured) no CondosmartContext.OnConfiguring para permitir o uso do
  InMemoryDatabase nos testes sem conflito com o provider MySQL.
  
  Resolved #236 