### PR TITLE
feat(testes): adicionar 3 testes funcionais E2E com Selenium

### DIFF
--- a/Codigo/Condosmart/CondosmartWeb.Test/UI/GestaoCondominioE2ETests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/UI/GestaoCondominioE2ETests.cs
@@ -1,0 +1,77 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Chrome;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+
+namespace CondosmartWeb.Tests.UI
+{
+    [TestClass]
+    public class GestaoCondominioE2ETests
+    {
+        private IWebDriver? _driver;
+        private const string BaseUrl = "https://localhost:7290";
+        private const string AdminEmail = "admin@condosmart.com";
+        private const string AdminPassword = "Admin@123";
+
+        [TestInitialize]
+        public void Setup()
+        {
+            var options = new ChromeOptions();
+            options.AcceptInsecureCertificates = true;
+            _driver = new ChromeDriver(options);
+            _driver.Manage().Timeouts().ImplicitWait = TimeSpan.FromSeconds(10);
+            _driver.Manage().Window.Maximize();
+        }
+
+        [TestCleanup]
+        public void Teardown()
+        {
+            _driver?.Quit();
+        }
+
+        [TestMethod]
+        public void CondominioIndex_DeveCarregarPaginaComBotaoNovo()
+        {
+            _driver!.Navigate().GoToUrl($"{BaseUrl}/Identity/Account/Login?ReturnUrl=%2F");
+            var loginPage = new LoginPage(_driver);
+            var dashboardPage = loginPage.Login(AdminEmail, AdminPassword);
+
+            _driver.Navigate().GoToUrl($"{BaseUrl}/Condominio");
+            var condominioPage = new CondominioIndexPage(_driver);
+
+            Assert.IsTrue(condominioPage.PaginaCarregada(), "A página de Condomínios não carregou corretamente");
+            Assert.IsTrue(condominioPage.BotaoNovoCondominioVisivel(), "O botão 'Novo Condomínio' não está visível");
+        }
+
+        [TestMethod]
+        public void ChamadoCreate_SemDescricao_DeveExibirMensagemDeErro()
+        {
+            _driver!.Navigate().GoToUrl($"{BaseUrl}/Identity/Account/Login?ReturnUrl=%2F");
+            var loginPage = new LoginPage(_driver);
+            var dashboardPage = loginPage.Login(AdminEmail, AdminPassword);
+
+            _driver.Navigate().GoToUrl($"{BaseUrl}/Chamado/Create");
+            var chamadoCreatePage = new ChamadoCreatePage(_driver);
+
+            chamadoCreatePage.LimparDescricao();
+            chamadoCreatePage.ClickSalvar();
+
+            string mensagemErro = chamadoCreatePage.ObterMensagemErroDescricao();
+            Assert.IsFalse(string.IsNullOrEmpty(mensagemErro), "A mensagem de erro de validação da descrição não foi exibida");
+        }
+
+        [TestMethod]
+        public void VisitanteIndex_DeveCarregarPaginaComBotaoNovo()
+        {
+            _driver!.Navigate().GoToUrl($"{BaseUrl}/Identity/Account/Login?ReturnUrl=%2F");
+            var loginPage = new LoginPage(_driver);
+            var dashboardPage = loginPage.Login(AdminEmail, AdminPassword);
+
+            _driver.Navigate().GoToUrl($"{BaseUrl}/Visitante");
+            var visitantePage = new VisitanteIndexPage(_driver);
+
+            Assert.IsTrue(visitantePage.PaginaCarregada(), "A página de Visitantes não carregou corretamente");
+            Assert.IsTrue(visitantePage.BotaoNovoVisitanteVisivel(), "O botão 'Novo Visitante' não está visível");
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/ChamadoPages.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/ChamadoPages.cs
@@ -1,0 +1,77 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+
+namespace CondosmartWeb.Tests.UI
+{
+    public class ChamadoIndexPage
+    {
+        private IWebDriver _driver;
+        private WebDriverWait _wait;
+
+        private By PageHeading => By.XPath("//h2[contains(text(), 'Chamados')]");
+        private By NovoChamadoButton => By.XPath("//a[contains(@href, 'Chamado/Create')]");
+
+        public ChamadoIndexPage(IWebDriver driver)
+        {
+            _driver = driver;
+            _wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+        }
+
+        public bool PaginaCarregada()
+        {
+            try
+            {
+                return _wait.Until(d => d.FindElement(PageHeading).Displayed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public ChamadoCreatePage ClickNovoChamado()
+        {
+            var elemento = _wait.Until(d => d.FindElement(NovoChamadoButton));
+            ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].click();", elemento);
+            return new ChamadoCreatePage(_driver);
+        }
+    }
+
+    public class ChamadoCreatePage
+    {
+        private IWebDriver _driver;
+        private WebDriverWait _wait;
+
+        private By DescricaoTextarea => By.Id("Descricao");
+        private By DescricaoErrorSpan => By.Id("Descricao-error");
+        private By SalvarButton => By.XPath("//button[contains(normalize-space(), 'Salvar')]");
+
+        public ChamadoCreatePage(IWebDriver driver)
+        {
+            _driver = driver;
+            _wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+        }
+
+        public void LimparDescricao()
+        {
+            var textarea = _wait.Until(d => d.FindElement(DescricaoTextarea));
+            textarea.Clear();
+        }
+
+        public void ClickSalvar()
+        {
+            var botao = _wait.Until(d => d.FindElement(SalvarButton));
+            ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].click();", botao);
+        }
+
+        public string ObterMensagemErroDescricao()
+        {
+            return _wait.Until(d =>
+            {
+                var el = d.FindElement(DescricaoErrorSpan);
+                return el.Displayed ? el.Text : string.Empty;
+            });
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/CondominioPages.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/CondominioPages.cs
@@ -1,0 +1,84 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+
+namespace CondosmartWeb.Tests.UI
+{
+    public class CondominioIndexPage
+    {
+        private IWebDriver _driver;
+        private WebDriverWait _wait;
+
+        private By PageHeading => By.XPath("//h2[contains(text(), 'Condom')]");
+        private By NovoCondominioButton => By.XPath("//a[contains(@href, 'Condominio/Create')]");
+        private By TabelaCondominios => By.CssSelector("table");
+
+        public CondominioIndexPage(IWebDriver driver)
+        {
+            _driver = driver;
+            _wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+        }
+
+        public bool PaginaCarregada()
+        {
+            try
+            {
+                return _wait.Until(d => d.FindElement(PageHeading).Displayed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool BotaoNovoCondominioVisivel()
+        {
+            try
+            {
+                return _wait.Until(d => d.FindElement(NovoCondominioButton).Displayed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public CondominioCreatePage ClickNovoCondominio()
+        {
+            var elemento = _wait.Until(d => d.FindElement(NovoCondominioButton));
+            ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].click();", elemento);
+            return new CondominioCreatePage(_driver);
+        }
+    }
+
+    public class CondominioCreatePage
+    {
+        private IWebDriver _driver;
+        private WebDriverWait _wait;
+
+        private By NomeInput => By.Id("Nome");
+        private By NomeErrorSpan => By.Id("Nome-error");
+        private By SalvarButton => By.XPath("//button[contains(normalize-space(), 'Salvar')]");
+
+        public CondominioCreatePage(IWebDriver driver)
+        {
+            _driver = driver;
+            _wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+        }
+
+        public void ClickSalvar()
+        {
+            var botao = _wait.Until(d => d.FindElement(SalvarButton));
+            ((IJavaScriptExecutor)_driver).ExecuteScript("arguments[0].click();", botao);
+        }
+
+        public string ObterMensagemErroNome()
+        {
+            return _wait.Until(d =>
+            {
+                var el = d.FindElement(NomeErrorSpan);
+                return el.Displayed ? el.Text : string.Empty;
+            });
+        }
+    }
+}

--- a/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/VisitantePages.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/UI/Pages/VisitantePages.cs
@@ -1,0 +1,45 @@
+using OpenQA.Selenium;
+using OpenQA.Selenium.Support.UI;
+using System;
+
+namespace CondosmartWeb.Tests.UI
+{
+    public class VisitanteIndexPage
+    {
+        private IWebDriver _driver;
+        private WebDriverWait _wait;
+
+        private By PageHeading => By.XPath("//h2[contains(text(), 'Visitantes')]");
+        private By NovoVisitanteButton => By.XPath("//a[contains(@href, 'Visitante/Create')]");
+
+        public VisitanteIndexPage(IWebDriver driver)
+        {
+            _driver = driver;
+            _wait = new WebDriverWait(driver, TimeSpan.FromSeconds(10));
+        }
+
+        public bool PaginaCarregada()
+        {
+            try
+            {
+                return _wait.Until(d => d.FindElement(PageHeading).Displayed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+
+        public bool BotaoNovoVisitanteVisivel()
+        {
+            try
+            {
+                return _wait.Until(d => d.FindElement(NovoVisitanteButton).Displayed);
+            }
+            catch
+            {
+                return false;
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Descrição

  Automatização de 3 casos de testes funcionais E2E utilizando Selenium WebDriver, seguindo o padrão Page Object já
  existente no projeto.

  ## Testes adicionados

  1. **CondominioIndex_DeveCarregarPaginaComBotaoNovo** - Verifica se a página de listagem de Condomínios carrega
  corretamente e exibe o botão "Novo Condomínio".

  2. **ChamadoCreate_SemDescricao_DeveExibirMensagemDeErro** - Verifica se ao tentar criar um Chamado sem preencher a
  descrição, a mensagem de validação é exibida corretamente.

  3. **VisitanteIndex_DeveCarregarPaginaComBotaoNovo** - Verifica se a página de listagem de Visitantes carrega
  corretamente e exibe o botão "Novo Visitante".

  ## Arquivos criados

  - `CondosmartWeb.Test/UI/GestaoCondominioE2ETests.cs` - Classe de testes E2E
  - `CondosmartWeb.Test/UI/Pages/CondominioPages.cs` - Page Objects de Condomínio
  - `CondosmartWeb.Test/UI/Pages/ChamadoPages.cs` - Page Objects de Chamado
  - `CondosmartWeb.Test/UI/Pages/VisitantePages.cs` - Page Objects de Visitante

  ## Padrão seguido

  - MSTest + Selenium WebDriver + ChromeDriver
  - Page Object Pattern (mesmo padrão de `AreaLazerPages.cs`)
  - Login via `LoginPage` com credenciais de admin

  Resolved #240