### PR TITLE
Criação de testes da atividade

### DIFF
--- a/Codigo/Condosmart/CondosmartWeb.Test/Controllers/ChamadoControllerTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Controllers/ChamadoControllerTests.cs
@@ -1,9 +1,10 @@
 using AutoMapper;
 using CondosmartWeb.Controllers;
+using CondosmartWeb.Models;
+using Core.Models;
 using Core.Service;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.Mvc.Routing;
 using Microsoft.AspNetCore.Mvc.ViewFeatures;
 using System.Security.Claims;
 using Moq;
@@ -13,18 +14,78 @@ namespace CondosmartWeb.Controllers.Tests
     [TestClass]
     public class ChamadoControllerTests
     {
-        private Mock<IChamadosService> mockService = null!;
+        private ChamadoController controller = null!;
 
         [TestInitialize]
         public void Initialize()
         {
-            mockService = new Mock<IChamadosService>();
+            var mockService = new Mock<IChamadosService>();
+            var mockCondominioService = new Mock<ICondominioService>();
+            var mockMoradorService = new Mock<IMoradorService>();
+            var mockSindicoService = new Mock<ISindicoService>();
+            var mockContextService = new Mock<ICondominioContextService>();
+            var mockNotificacaoService = new Mock<INotificacaoService>();
+            var mapper = new Mock<IMapper>();
+
+            mockService.Setup(s => s.GetAll()).Returns(GetTestChamados());
+            mockService.Setup(s => s.GetById(1)).Returns(GetTargetChamado());
+
+            mapper.Setup(m => m.Map<List<ChamadoViewModel>>(It.IsAny<List<Chamado>>())).Returns((List<Chamado> src) => src.Select(ToViewModel).ToList());
+            mapper.Setup(m => m.Map<ChamadoViewModel>(It.IsAny<Chamado>())).Returns((Chamado src) => ToViewModel(src));
+
+            mockCondominioService.Setup(s => s.GetAll()).Returns(new List<Condominio>());
+            mockContextService.Setup(s => s.GetCondominioAtualId()).Returns(1);
+
+            controller = new ChamadoController(
+                mockService.Object,
+                mockCondominioService.Object,
+                mockMoradorService.Object,
+                mockSindicoService.Object,
+                mockContextService.Object,
+                mockNotificacaoService.Object,
+                mapper.Object);
+
+            var httpContext = new DefaultHttpContext();
+            httpContext.User = new ClaimsPrincipal(new ClaimsIdentity(new[] { new Claim(ClaimTypes.Name, "teste@condo.com") }, "TestAuth"));
+            controller.ControllerContext = new ControllerContext { HttpContext = httpContext };
+            controller.TempData = new TempDataDictionary(httpContext, Mock.Of<ITempDataProvider>());
+            var url = new Mock<IUrlHelper>();
+            url.Setup(u => u.Action(It.IsAny<UrlActionContext>())).Returns("/teste");
+            controller.Url = url.Object;
         }
 
         [TestMethod]
-        public void ChamadoControllerExists()
+        public void Index_Returns_View_With_List()
         {
-            Assert.IsNotNull(mockService.Object);
+            var result = controller.Index();
+
+            Assert.IsInstanceOfType(result, typeof(ViewResult));
+            var model = (List<ChamadoViewModel>)((ViewResult)result).ViewData.Model!;
+            Assert.AreEqual(2, model.Count);
         }
+
+        [TestMethod]
+        public void Details_InvalidId_Returns_NotFound()
+        {
+            var result = controller.Details(999);
+            Assert.IsInstanceOfType(result, typeof(NotFoundResult));
+        }
+
+        [TestMethod]
+        public void Create_Post_InvalidModel_Returns_View()
+        {
+            var vm = new ChamadoViewModel { Id = 0, Descricao = "", Status = "aberto", CondominioId = 1 };
+            controller.ModelState.AddModelError("Descricao", "Obrigatório");
+
+            var result = controller.Create(vm);
+
+            Assert.IsInstanceOfType(result, typeof(ViewResult));
+            var viewResult = (ViewResult)result;
+            Assert.IsInstanceOfType(viewResult.ViewData.Model, typeof(ChamadoViewModel));
+        }
+
+        private static ChamadoViewModel ToViewModel(Chamado src) => new() { Id = src.Id, Descricao = src.Descricao, Status = src.Status, CondominioId = src.CondominioId };
+        private static Chamado GetTargetChamado() => new() { Id = 1, Descricao = "Chamado 1", Status = "aberto", CondominioId = 1, DataChamado = DateTime.Now };
+        private static List<Chamado> GetTestChamados() => new() { GetTargetChamado(), new Chamado { Id = 2, Descricao = "Chamado 2", Status = "aberto", CondominioId = 1, DataChamado = DateTime.Now } };
     }
 }

--- a/Codigo/Condosmart/CondosmartWeb.Test/Service/ChamadoServiceIntegrationTests.cs
+++ b/Codigo/Condosmart/CondosmartWeb.Test/Service/ChamadoServiceIntegrationTests.cs
@@ -1,0 +1,72 @@
+using Core.Data;
+using Core.Models;
+using Microsoft.EntityFrameworkCore;
+using Service;
+
+namespace CondosmartWeb.Tests.Service
+{
+    [TestClass]
+    public class ChamadoServiceIntegrationTests
+    {
+        private CondosmartContext context = null!;
+        private ChamadoService service = null!;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            var options = new DbContextOptionsBuilder<CondosmartContext>()
+                .UseInMemoryDatabase(databaseName: $"IntegrationDb_{Guid.NewGuid()}")
+                .Options;
+
+            context = new CondosmartContext(options);
+            service = new ChamadoService(context);
+
+            context.Condominios.Add(new Condominio { Id = 1, Nome = "Condominio Integracao", Cnpj = "12345678000195" });
+            context.SaveChanges();
+        }
+
+        [TestCleanup]
+        public void Cleanup() => context?.Dispose();
+
+        [TestMethod]
+        public void Create_Integration_CriaChamadoNaBase()
+        {
+            var chamado = new Chamado { Descricao = "Chamado Integration", Status = "aberto", CondominioId = 1 };
+
+            int id = service.Create(chamado);
+
+            var fromDb = context.Chamados.Find(id);
+            Assert.IsNotNull(fromDb);
+            Assert.AreEqual("Chamado Integration", fromDb!.Descricao);
+        }
+
+        [TestMethod]
+        public void Edit_Integration_AtualizaChamadoNaBase()
+        {
+            var chamado = new Chamado { Descricao = "ParaEditar", Status = "aberto", CondominioId = 1 };
+            int id = service.Create(chamado);
+
+            var criado = service.GetById(id)!;
+            criado.Status = "resolvido";
+            criado.Descricao = "Editado";
+            service.Edit(criado);
+
+            var after = context.Chamados.Find(id);
+            Assert.IsNotNull(after);
+            Assert.AreEqual("resolvido", after!.Status);
+            Assert.AreEqual("Editado", after.Descricao);
+        }
+
+        [TestMethod]
+        public void Delete_Integration_RemoveChamadoDaBase()
+        {
+            var chamado = new Chamado { Descricao = "ParaRemover", Status = "aberto", CondominioId = 1 };
+            int id = service.Create(chamado);
+
+            service.Delete(id);
+
+            var after = context.Chamados.Find(id);
+            Assert.IsNull(after);
+        }
+    }
+}


### PR DESCRIPTION
Na Controller, foram criados testes unitários (MSTest) do ChamadoController: verificam que Index retorna a view com a lista de chamados, que Details retorna NotFound para id inexistente e que Create (POST) com ModelState inválido retorna a mesma view com o modelo — usando Moq e configuração mínima de HttpContext/TempData.

Na Service, foram criados testes de integração (MSTest) do ChamadoService: verificam que Create persiste um chamado, Edit atualiza os dados e Delete remove o registro — executados com InMemoryDatabase para simular o EF Core.